### PR TITLE
Fix `Rotate` type instability

### DIFF
--- a/src/projective/affine.jl
+++ b/src/projective/affine.jl
@@ -107,11 +107,14 @@ Rotate(γ) = Rotate(Uniform(-abs(γ), abs(γ)))
 
 getrandstate(tfm::Rotate) = rand(tfm.dist)
 
-function getprojection(tfm::Rotate, bounds; randstate = getrandstate(tfm))
+function getprojection(
+        tfm::Rotate,
+        bounds::AbstractArray{<:SVector{N, T}};
+        randstate = getrandstate(tfm)) where {N, T}
     γ = randstate
     middlepoint = sum(bounds) ./ length(bounds)
     r = γ / 360 * 2pi
-    return recenter(RotMatrix(r), middlepoint)
+    return recenter(RotMatrix(convert(T, r)), middlepoint)
 end
 
 

--- a/src/projective/base.jl
+++ b/src/projective/base.jl
@@ -49,6 +49,7 @@ Default implementation falls back to `project`.
 function project!(bufitem, P, item, indices)
     titem = project(P, item, indices)
     copyitemdata!(bufitem, titem)
+
     return bufitem
 end
 
@@ -82,8 +83,8 @@ function apply!(
     bounds = getbounds(item)
     P = getprojection(tfm, bounds; randstate = randstate)
     indices = cropindices(tfm, P, bounds; randstate = randstate)
-    project!(bufitem, P, item, indices)
-    return bufitem
+    res = project!(bufitem, P, item, indices)
+    return res
 end
 
 

--- a/src/projective/warp.jl
+++ b/src/projective/warp.jl
@@ -42,5 +42,5 @@ function threepointwarpaffine(
     c = (X \ Y)'
     A = SMatrix{2, 2, V}(c[:, 1:2])
     b = SVector{2, V}(c[:, 3])
-    AffineMap(A, b)
+    return AffineMap(A, b)
 end


### PR DESCRIPTION
`Rotate` would always return a transformation with `Float64` values, resulting in `Float64` bounds in output items.