### PR TITLE
Add Normalize path for Image

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -81,6 +81,12 @@ function apply!(
     return buf
 end
 
+function apply(tfm::Normalize, item::Image; randstate = nothing)
+    tensor = imagetotensor(itemdata(item))
+    output = normalize(tensor, tfm.means, tfm.stds)
+
+    return Image(tensortoimage(output), item.bounds)
+end
 
 function normalize!(
         a::AbstractArray{T, N},

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -21,7 +21,7 @@ include("./imports.jl")
         item2 = ArrayItem(rand(10, 10, 3))
         testapply!(tfm, item1, item2)
         image = Image(zeros(RGB, 32, 32))
-        @test _channelview(itemdata(apply(tfm, item))) ≈ -1 .* ones(32, 32, 3)
+        @test DataAugmentation._channelview(itemdata(apply(tfm, item))) ≈ -1 .* ones(32, 32, 3)
     end
 end
 

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -20,6 +20,8 @@ include("./imports.jl")
         item1 = ArrayItem(rand(10, 10, 3))
         item2 = ArrayItem(rand(10, 10, 3))
         testapply!(tfm, item1, item2)
+        image = Image(zeros(RGB, 32, 32))
+        @test _channelview(itemdata(apply(tfm, item))) ≈ -1 .* ones(32, 32, 3)
     end
 end
 


### PR DESCRIPTION
This adds a dispatch so that `Normalize` can be used on an `Image` (i.e. colorant array). Useful when you need to normalize data then apply augmentations on top of that without converting back and forth.