### PR TITLE
Fix crop-projective composition

### DIFF
--- a/src/projective/crop.jl
+++ b/src/projective/crop.jl
@@ -101,6 +101,10 @@ function compose(composed::ComposedProjectiveTransform, cropped::CroppedProjecti
 
 end
 
+function compose(cropped::CroppedProjectiveTransform, projective::ProjectiveTransform)
+    return Sequence(cropped, projective)
+end
+
 
 """
     offsetcropbounds(sz, bounds, offsets)

--- a/test/projective/affine.jl
+++ b/test/projective/affine.jl
@@ -157,11 +157,12 @@ end
     @testset ExtendedTestSet "2D" begin
         tfms = compose(
             Rotate(10),
-            FlipX(), FlipY(),
+            FlipX(),
+            FlipY(),
             ScaleRatio((.8, .8)),
-            RandomCrop((10, 10)),
             WarpAffine(0.1),
-            Zoom((1., 1.2))
+            Zoom((1., 1.2)),
+            RandomCrop((10, 10)),
         )
         testprojective(tfms)
     end


### PR DESCRIPTION
Fixes a bug (reported in #62) where composing a `CroppedProjectiveTransform` with another `ProjectiveTransform` would cause the cropping to be skipped. Now, this instead creates a `Sequence` meaning the crop is properly applied; however, the last projection is not fused with that before the crop.

Closes #62