### PR TITLE
Fix RandomCrop transform

### DIFF
--- a/src/projective/crop.jl
+++ b/src/projective/crop.jl
@@ -117,7 +117,8 @@ the crop by `offsets[i]` times the difference between the two.
 function offsetcropbounds(
         sz::NTuple{N, Int},
         bounds::Bounds{N},
-        offsets::NTuple{N, <:Number}) where N
+        offsets::NTuple{N, T}) where {N, T<:AbstractFloat}
+    offsets = map(o -> o == one(T) ? one(T) - eps(T) : o, offsets)
     indices = bounds.rs
     mins = getindex.(indices, 1)
     diffs = length.(indices) .- sz .+ 1

--- a/src/projective/crop.jl
+++ b/src/projective/crop.jl
@@ -122,7 +122,7 @@ function offsetcropbounds(
     mins = getindex.(indices, 1)
     diffs = length.(indices) .- sz
 
-    startindices = floor.(Int, mins .+ (diffs .* offsets))
+    startindices = round.(Int, mins .+ (diffs .* offsets))
     endindices = startindices .+ sz .- 1
 
     bs = Bounds(UnitRange.(startindices, endindices))

--- a/src/projective/crop.jl
+++ b/src/projective/crop.jl
@@ -120,9 +120,9 @@ function offsetcropbounds(
         offsets::NTuple{N, <:Number}) where N
     indices = bounds.rs
     mins = getindex.(indices, 1)
-    diffs = length.(indices) .- sz
+    diffs = length.(indices) .- sz .+ 1
 
-    startindices = round.(Int, mins .+ (diffs .* offsets))
+    startindices = floor.(Int, mins .+ (diffs .* offsets))
     endindices = startindices .+ sz .- 1
 
     bs = Bounds(UnitRange.(startindices, endindices))


### PR DESCRIPTION
Fix RandomCrop transform missing one offset position, use round() instead of floor() for startindices.