### PR TITLE
Make clamp01 optional in AdjustBrightness and AdjustContrast

### DIFF
--- a/src/colortransforms.jl
+++ b/src/colortransforms.jl
@@ -9,6 +9,8 @@ from `f ∈ [1-δ, 1+δ]` by multiplying each color channel by `f`.
 You can also pass any `Distributions.Sampleable` from which the
 factor is selected.
 
+Pixels are clamped to [0,1] unless `clamp=false` is passed.
+
 ## Example
 
 {cell=AdjustBrightness}
@@ -23,36 +25,37 @@ showgrid(titems; ncol = 4, npad = 16)
 """
 struct AdjustBrightness{S<:Sampleable} <: Transform
     dist::S
+    clamp::Bool
 end
 
-AdjustBrightness(f::Real) = AdjustBrightness(Uniform(max(0, 1 - f), 1 + f))
+AdjustBrightness(f::Real; clamp::Bool=true) = AdjustBrightness(Uniform(max(0, 1 - f), 1 + f), clamp)
 
 getrandstate(tfm::AdjustBrightness) = rand(tfm.dist)
 
 
 function apply(tfm::AdjustBrightness, item::Image; randstate = getrandstate(tfm))
     factor = randstate
-    return setdata(item, adjustbrightness(itemdata(item), factor))
+    return setdata(item, adjustbrightness(itemdata(item), factor, tfm.clamp))
 end
 
 function apply!(buf, tfm::AdjustBrightness, item::Image; randstate = getrandstate(tfm))
     factor = randstate
-    adjustbrightness!(itemdata(buf), itemdata(item), factor)
+    adjustbrightness!(itemdata(buf), itemdata(item), factor, tfm.clamp)
     return buf
 end
 
 
-function adjustbrightness(img, factor)
-    return adjustbrightness!(copy(img), factor)
+function adjustbrightness(img, factor, clamp)
+    return adjustbrightness!(copy(img), factor, clamp)
 end
 
 
-adjustbrightness!(img, factor) = adjustbrightness!(img, img, factor)
+adjustbrightness!(img, factor, clamp) = adjustbrightness!(img, img, factor, clamp)
 
 # TODO: add methods for non-RGB/Gray images
-function adjustbrightness!(dst::AbstractArray{U}, img::AbstractArray{T}, factor) where {T, U}
+function adjustbrightness!(dst::AbstractArray{U}, img::AbstractArray{T}, factor, clamp) where {T, U}
     map!(dst, img) do x
-        convert(U, clamp01(x * factor))
+        convert(U, clamp ? clamp01(x * factor) : x * factor)
     end
 end
 
@@ -70,6 +73,8 @@ of the image.
 You can also pass any `Distributions.Sampleable` from which the
 factor is selected.
 
+Pixels are clamped to [0,1] unless `clamp=false` is passed.
+
 ## Example
 
 {cell=AdjustBrightness}
@@ -84,36 +89,37 @@ showgrid(titems; ncol = 4, npad = 16)
 """
 struct AdjustContrast{S<:Sampleable} <: Transform
     dist::S
+    clamp::Bool
 end
 
-AdjustContrast(f::Real) = AdjustContrast(Uniform(max(0, 1 - f), 1 + f))
+AdjustContrast(f::Real; clamp::Bool=true) = AdjustContrast(Uniform(max(0, 1 - f), 1 + f), clamp)
 
 getrandstate(tfm::AdjustContrast) = rand(tfm.dist)
 
 
 function apply(tfm::AdjustContrast, item::Image; randstate = getrandstate(tfm))
     factor = randstate
-    return setdata(item, adjustcontrast(itemdata(item), factor))
+    return setdata(item, adjustcontrast(itemdata(item), factor, tfm.clamp))
 end
 
 function apply!(buf, tfm::AdjustContrast, item::Image; randstate = getrandstate(tfm))
     factor = randstate
-    adjustcontrast!(itemdata(buf), itemdata(item), factor)
+    adjustcontrast!(itemdata(buf), itemdata(item), factor, tfm.clamp)
     return buf
 end
 
 
-function adjustcontrast(img, factor)
-    return adjustcontrast!(copy(img), factor)
+function adjustcontrast(img, factor, clamp)
+    return adjustcontrast!(copy(img), factor, clamp)
 end
 
 
 # TODO: add methods for non-RGB/Gray images
-function adjustcontrast!(dst::AbstractArray{U}, img::AbstractArray{T}, factor) where {T, U}
+function adjustcontrast!(dst::AbstractArray{U}, img::AbstractArray{T}, factor, clamp) where {T, U}
     μ = mean(img)
     map!(dst, img) do x
-        convert(U, clamp01(x + μ * (1 - factor)))
+        convert(U, clamp ? clamp01(x + μ * (1 - factor)) : x + μ * (1 - factor))
     end
 end
 
-adjustcontrast!(img, factor) = adjustcontrast!(img, img, factor)
+adjustcontrast!(img, factor, clamp) = adjustcontrast!(img, img, factor, clamp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,4 +47,7 @@ include("./imports.jl")
     @testset ExtendedTestSet "rowtransforms.jl" begin
         include("rowtransforms.jl")
     end
+    @testset ExtendedTestSet "colortransforms.jl" begin
+        include("colortransforms.jl")
+    end
 end


### PR DESCRIPTION
Closes #76 

- Added the optional `clamp` flag to `AdjustBrightness` and `AdjustContrast`
- Added colortransforms.jl to the tests (I think it was accidentally left out before)