### PR TITLE
fix documentation link: repository moved to FluxML

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DataAugmentation.jl
 
-[Documentation | Latest](https://lorenzoh.github.io/DataAugmentation.jl/dev/documents/README.md)
+[Documentation | Latest](https://fluxml.github.io/DataAugmentation.jl/dev/documents/README.md)
 
 Efficient, composable data augmentation for machine and deep learning with support for n-dimensional images, keypoints and categorical masks.


### PR DESCRIPTION
This repository moved to the FluxML repository, updated the documentation link accordingly

closes #80 
