### PR TITLE
Remove unused type variable

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -212,7 +212,7 @@ function _channelview(img)
     return chview
 end
 
-function _colorview(C::Type{<:Color}, img) where T
+function _colorview(C::Type{<:Color}, img)
     if size(img, 1) == 1
         img = reshape(img, size(img)[2:end])
     end


### PR DESCRIPTION
This previously threw a warning when running tests:
```
 WARNING: method definition for _colorview at /Users/funks/Developer/DataAugmentation.jl/src/preprocessing.jl:215 declares type variable T but does not use it.
```