### PR TITLE
Make `ImageToTensor` compatible with Flux's `WHC` format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Added
+
+- Add `PermuteDims` transformation
+
+### Changed
+
+- `ImageToTensor` now returns arrays in `WHC` format instead of `HWC` 
+
+## [0.2.12]
+
+### Added
+
+- Added optional `clamp` flag to `AdjustBrightness` and `AdjustContrast`
+
+### Changed
+
+- Transfered repository to FluxML
+
+## [0.2.11]
+
+### Fixed
+
+- Bump Setfield compat
+
+## [0.2.10]
+
+### Fixed 
+
+- Fix `RandomCrop` transform
+
+## [0.2.9]
+
+### Added 
+
+- Set up Pollen.jl documentation 
+
+### Fixed 
+
+- Fix deprecated call to `warp`
+
+## [0.2.8]
+
+### Fixed
+
+- Fix compatibility with ImageTransformations 0.9
+
+## [0.2.7]
+
+### Changed
+
+- Replace Images.jl dependency with ImageCore.jl
+
+### Fixed
+
+- Fix crop-projective composition
+
 ## [0.2.6]
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DataAugmentation"
 uuid = "88a5189c-e7ff-4f85-ac6b-e6158070f02e"
 authors = ["lorenzoh <lorenz.ohly@gmail.com>"]
-version = "0.2.12"
+version = "0.3.0"
 
 [deps]
 ColorBlendModes = "60508b50-96e1-4007-9d6c-f475c410f16b"

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -102,7 +102,7 @@ end
 
     res = apply(tfm, item1)
     a = itemdata(res)
-    @test size(a) == (32, 48, 3)
+    @test size(a) == (48, 32, 3)
     @test eltype(a) == Float32
 
     testapply(tfm, item1)


### PR DESCRIPTION
As discussed in https://github.com/FluxML/DataAugmentation.jl/pull/89#issuecomment-1986872309, this PR modifies `ImageToTensor` to return `WHC` arrays instead of `HWC` by default, making it out-of-the box compatible with Flux and Metalhead.jl.


@darsnack's previous suggestion was:

> For now, why don't we throw a deprecation warning in `ImageToTensor` with instructions how to get `HWC` in the future using (fixed) `ImageToTensor` + `PermuteDims`?

However, a release including this PR could be considered breaking since it might break users' existing data preprocessing pipelines.

---
Related issues: 
* https://github.com/FluxML/DataAugmentation.jl/issues/56#issuecomment-1934425306
* https://github.com/FluxML/Metalhead.jl/issues/275
