### PR TITLE
Fix ScaleKeepAspect scaling to wrong size

### DIFF
--- a/src/projective/affine.jl
+++ b/src/projective/affine.jl
@@ -60,7 +60,7 @@ end
 function projectionbounds(tfm::ScaleKeepAspect{N}, P, bounds::Bounds{N}; randstate = nothing) where N
     origsz = length.(bounds.rs)
     ratio = maximum((tfm.minlengths) ./ origsz)
-    sz = floor.(Int,ratio .* origsz)
+    sz = round.(Int, ratio .* origsz)
     bounds_ = transformbounds(bounds, P)
     bs_ = offsetcropbounds(sz, bounds_, ntuple(_ -> 0.5, N))
     return bs_

--- a/test/projective/affine.jl
+++ b/test/projective/affine.jl
@@ -94,9 +94,12 @@ include("../imports.jl")
 
         @testset ExtendedTestSet "ScaleKeepAspect" begin
             tfm = ScaleKeepAspect((32, 32))
+
             img = rand(RGB{N0f8}, 64, 96)
             @test apply(tfm, Image(img)) |> itemdata |> size == (32, 48)
 
+            img = rand(RGB{N0f8}, 196, 196)
+            @test apply(tfm, Image(img)) |> itemdata |> size == (32, 32)
         end
     end
 


### PR DESCRIPTION
Addresses ScaleKeepAspect not scaling to the requested size due to floating point imprecision. This also adds an example case to the unit tests.

### PR Checklist

- [x] Tests are added
- [ ] Documentation, if applicable
