### PR TITLE
Fix black borders (once and for all)

### DIFF
--- a/src/projective/affine.jl
+++ b/src/projective/affine.jl
@@ -76,7 +76,7 @@ function getprojection(scale::ScaleFixed, bounds::Bounds{N}; randstate = nothing
     # If no scaling needs to be done, return a noop transform
     (scale.sizes == length.(bounds.rs)) && return IdentityTransformation()
 
-    ratios = (scale.sizes .+ 1) ./ length.(bounds.rs)
+    ratios = (scale.sizes .+ 2) ./ length.(bounds.rs)
     upperleft = SVector{N, Float32}(minimum.(bounds.rs)) .- 1
     P = scaleprojection(ratios)
     if any(upperleft .!= 0)
@@ -111,7 +111,12 @@ getrandstate(tfm::Zoom) = rand(tfm.dist)
 
 function getprojection(tfm::Zoom, bounds::Bounds{N}; randstate = getrandstate(tfm)) where N
     ratio = randstate
-    return scaleprojection(ntuple(_ -> ratio, N))
+    return getprojection(ScaleRatio{N}(ntuple(_ -> ratio, N)), bounds; randstate = nothing)
+end
+
+function projectionbounds(tfm::Zoom, P, bounds::Bounds{N}; randstate = getrandstate(tfm)) where N
+    ratio = randstate
+    projectionbounds(ScaleFixed{N}(fixed_sizes(ScaleRatio{N}(ntuple(_ -> ratio, N)), bounds)), P, bounds; randstate = nothing)
 end
 
 """

--- a/test/projective/affine.jl
+++ b/test/projective/affine.jl
@@ -82,7 +82,7 @@ include("../imports.jl")
             testprojective(tfm)
 
         end
-        
+
         @testset ExtendedTestSet "ScaleRatio" begin
             tfm = ScaleRatio((1/2, 1/2))
             @test_nowarn apply(tfm, image)


### PR DESCRIPTION
In my last PR, I thought I solved black borders in upscaling. However, for some image sizes those still remained.

Adding a pixel to every border of the image to be upscaled solves the black border issue.

However, I'm not sure how to solve the bounds issue. I'm not exactly sure how the `offsetbounds` work in this package or whether there is some issue remaining in `transformbounds`.

Therefore, tests currently fail. Maybe you can help me fix this.